### PR TITLE
Added cross compiling support for vsinpu

### DIFF
--- a/cmake/onnxruntime_providers.cmake
+++ b/cmake/onnxruntime_providers.cmake
@@ -1789,7 +1789,6 @@ endif()
 
 if (onnxruntime_USE_VSINPU)
   add_definitions(-DUSE_VSINPU=1)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-parameter")
   file(GLOB_RECURSE onnxruntime_providers_vsinpu_srcs
     "${ONNXRUNTIME_ROOT}/core/providers/vsinpu/builders/*.h"
     "${ONNXRUNTIME_ROOT}/core/providers/vsinpu/builders/*.cc"
@@ -1808,12 +1807,24 @@ if (onnxruntime_USE_VSINPU)
   target_include_directories(onnxruntime_providers_vsinpu PRIVATE ${ONNXRUNTIME_ROOT} $ENV{TIM_VX_INSTALL}/include)
 
   find_library(TIMVX_LIBRARY NAMES tim-vx PATHS $ENV{TIM_VX_INSTALL}/lib NO_DEFAULT_PATH)
-  if(TIMVX_LIBRARY)
-    target_link_libraries(onnxruntime_providers_vsinpu PRIVATE ${TIMVX_LIBRARY})
-  else()
-    message(FATAL_ERROR "Cannot find TIM-VX library!")
+  if(NOT TIMVX_LIBRARY)
+    message(FATAL_ERROR "TIM-VX library is not found!")
   endif()
 
+  if(CMAKE_CROSSCOMPILING)
+    message(STATUS "VSINPU ep will be cross compiled.")
+    if(EXISTS "$ENV{VIVANTE_SDK_DIR}/drivers")
+      set(DRIVER_DIR "$ENV{VIVANTE_SDK_DIR}/drivers")
+    elseif(EXISTS "$ENV{VIVANTE_SDK_DIR}/lib")
+      set(DRIVER_DIR "$ENV{VIVANTE_SDK_DIR}/lib")
+    else()
+      message(FATAL_ERROR "Neither drivers nor lib directory exists in this VIVANTE_SDK_DIR.")
+    endif()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-parameter -Wl,-rpath-link ${DRIVER_DIR} ${TIMVX_LIBRARY}")
+  else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-parameter")
+    target_link_libraries(onnxruntime_providers_vsinpu PRIVATE ${TIMVX_LIBRARY})
+  endif()
 endif()
 
 if (onnxruntime_USE_XNNPACK)

--- a/onnxruntime/core/providers/vsinpu/patches/mlas_crosscompiling.patch
+++ b/onnxruntime/core/providers/vsinpu/patches/mlas_crosscompiling.patch
@@ -1,0 +1,34 @@
+diff --git a/cmake/onnxruntime_mlas.cmake b/cmake/onnxruntime_mlas.cmake
+index e0ccc504d7..6c5aa6ea53 100644
+--- a/cmake/onnxruntime_mlas.cmake
++++ b/cmake/onnxruntime_mlas.cmake
+@@ -335,7 +335,7 @@ else()
+           ${MLAS_SRC_DIR}/qgemm_kernel_udot.cpp
+           ${MLAS_SRC_DIR}/qgemm_kernel_sdot.cpp
+         )
+-        if (NOT APPLE)
++        if (NOT APPLE AND NOT onnxruntime_USE_VSINPU)
+           set(mlas_platform_srcs
+             ${mlas_platform_srcs}
+             ${MLAS_SRC_DIR}/aarch64/HalfGemmKernelNeon.S
+diff --git a/onnxruntime/core/mlas/inc/mlas.h b/onnxruntime/core/mlas/inc/mlas.h
+index fd6b3df934..f81f1c42b6 100644
+--- a/onnxruntime/core/mlas/inc/mlas.h
++++ b/onnxruntime/core/mlas/inc/mlas.h
+@@ -79,6 +79,7 @@ Abstract:
+
+ #if (!defined(_MSC_VER)) || (_MSC_VER >= 1930)
+ #if defined(MLAS_TARGET_ARM64) || defined(MLAS_TARGET_ARM64EC)
++#if !defined(USE_VSINPU)
+ #if !defined(__APPLE__)
+ // Had to temporary disable fp16 under APPLE ARM64, as compiling
+ // the source files require a hardware specific compilation flag.
+@@ -87,7 +88,8 @@ Abstract:
+
+ #define MLAS_F16VEC_INTRINSICS_SUPPORTED
+
+-#endif //
++#endif
++#endif //
+ #endif // ARM64
+ #endif // Visual Studio 16 or earlier does not support fp16 intrinsic


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Added cmake flag control for cross compiling
Added patch for mlas modification


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- vsinpu would have linking error if not modify linker options in cross compilation process
- vsinpu met compilation error in cross building mlas, so need to hack some marcos to avoid some f16 settings


