### PR TITLE
Added Reshape/Concat/Softmax op support

### DIFF
--- a/onnxruntime/core/providers/vsinpu/builders/impl/base_op_builder.cc
+++ b/onnxruntime/core/providers/vsinpu/builders/impl/base_op_builder.cc
@@ -40,6 +40,7 @@ static bool IsTypeSupported(const NodeArg* node_arg) {
     case ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_UINT8:
     case ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_UINT16:
     case ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_INT32:
+    case ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_INT64:
       return true;
     default:
       return false;

--- a/onnxruntime/core/providers/vsinpu/builders/impl/concat_op_builder.h
+++ b/onnxruntime/core/providers/vsinpu/builders/impl/concat_op_builder.h
@@ -1,0 +1,63 @@
+/****************************************************************************
+ *
+ *    Copyright (c) 2024 Vivante Corporation
+ *
+ *    Permission is hereby granted, free of charge, to any person obtaining a
+ *    copy of this software and associated documentation files (the "Software"),
+ *    to deal in the Software without restriction, including without limitation
+ *    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *    and/or sell copies of the Software, and to permit persons to whom the
+ *    Software is furnished to do so, subject to the following conditions:
+ *
+ *    The above copyright notice and this permission notice shall be included in
+ *    all copies or substantial portions of the Software.
+ *
+ *    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *    DEALINGS IN THE SOFTWARE.
+ *
+ *****************************************************************************/
+#include "core/providers/vsinpu/builders/impl/base_op_builder.h"
+#include "core/providers/common.h"
+#include "core/providers/shared/utils/utils.h"
+
+namespace onnxruntime {
+namespace vsi {
+namespace npu {
+class ConcatOpBuilder : public BaseOpBuilder {
+  bool IsOpSupported(const onnxruntime::GraphViewer& graph_viewer,
+                     const Node* node) const override {
+    NodeAttrHelper helper(*node);
+    auto axis = helper.Get("axis", 0);
+    auto input_defs = node->InputDefs();
+    auto input_shape = vsi::npu::util::GetTensorShape(*input_defs[0]);
+    int32_t rank = input_shape.NumDimensions();
+    if (axis >= rank || axis < -rank) {
+      LOGS_DEFAULT(ERROR) << "Axis is invalid in Concat.";
+      return false;
+    }
+    return true;
+  }
+  bool HandleBuildOp(vsi::npu::GraphEP* graph_ep,
+                     std::vector<std::shared_ptr<tim::vx::Tensor>>& inputs,
+                     std::vector<std::shared_ptr<tim::vx::Tensor>>& outputs,
+                     const Node* node) override {
+    LOGS_DEFAULT(VERBOSE) << "Creating Concat Op.";
+    NodeAttrHelper helper(*node);
+    auto axis = helper.Get("axis", 0);
+    axis = HandleNegativeAxis(axis, inputs[0]->GetShape().size());
+    axis = inputs[0]->GetShape().size() - axis - 1;
+    auto op = graph_ep->GetGraph()->CreateOperation<tim::vx::ops::Concat>(static_cast<uint32_t>(axis), inputs.size());
+    (*op).BindInputs(inputs).BindOutputs(outputs);
+    graph_ep->GetOps().push_back(std::move(op));
+    return true;
+  }
+};
+}  // namespace npu
+
+}  // namespace vsi
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/vsinpu/builders/impl/softmax_op_builder.h
+++ b/onnxruntime/core/providers/vsinpu/builders/impl/softmax_op_builder.h
@@ -1,0 +1,89 @@
+/****************************************************************************
+ *
+ *    Copyright (c) 2024 Vivante Corporation
+ *
+ *    Permission is hereby granted, free of charge, to any person obtaining a
+ *    copy of this software and associated documentation files (the "Software"),
+ *    to deal in the Software without restriction, including without limitation
+ *    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *    and/or sell copies of the Software, and to permit persons to whom the
+ *    Software is furnished to do so, subject to the following conditions:
+ *
+ *    The above copyright notice and this permission notice shall be included in
+ *    all copies or substantial portions of the Software.
+ *
+ *    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *    DEALINGS IN THE SOFTWARE.
+ *
+ *****************************************************************************/
+#include "core/providers/vsinpu/builders/impl/base_op_builder.h"
+#include "core/providers/common.h"
+#include "core/providers/shared/utils/utils.h"
+
+namespace onnxruntime {
+namespace vsi {
+namespace npu {
+class SoftmaxOpBuilder : public BaseOpBuilder {
+  bool IsOpSupported(const onnxruntime::GraphViewer& graph_viewer,
+                     const Node* node) const override {
+    NodeAttrHelper helper(*node);
+    auto axis = helper.Get("axis", -1);
+    auto input_defs = node->InputDefs();
+    auto input_shape = vsi::npu::util::GetTensorShape(*input_defs[0]);
+    int32_t rank = input_shape.NumDimensions();
+    if (axis >= rank || axis < -rank) {
+      LOGS_DEFAULT(ERROR) << "Axis is invalid in Softmax.";
+      return false;
+    }
+    return true;
+  }
+  bool HandleBuildOp(vsi::npu::GraphEP* graph_ep,
+                     std::vector<std::shared_ptr<tim::vx::Tensor>>& inputs,
+                     std::vector<std::shared_ptr<tim::vx::Tensor>>& outputs,
+                     const Node* node) override {
+    LOGS_DEFAULT(VERBOSE) << "Creating Softmax Op.";
+    NodeAttrHelper helper(*node);
+    int32_t def_val = node->SinceVersion() < 13 ? 1 : -1;
+    auto axis = helper.Get("axis", def_val);
+
+    if (node->SinceVersion() < 13) {
+      // In earlier opset version of softmax, input is coerced into 2D shape
+      // Attribute "axis" is to describe the axis of the inputs when coerced to 2D but not take part in softmax computation
+
+      axis = HandleNegativeAxis(axis, inputs[0]->GetShape().size());
+      auto it = inputs[0]->GetShape().end();
+      uint32_t last_dim = std::accumulate(it - axis, it, 1, std::multiplies<uint32_t>());
+      uint32_t first_dim = std::accumulate(inputs[0]->GetShape().begin(), it - axis, 1, std::multiplies<uint32_t>());
+      auto reshaped_spec = inputs[0]->GetSpec().AsTransientSpec().SetShape(std::vector<uint32_t>{first_dim, last_dim});
+      auto reshaped_input = graph_ep->GetGraph()->CreateTensor(reshaped_spec);
+      auto reshaped_output = graph_ep->GetGraph()->CreateTensor(inputs[0]->GetSpec().AsTransientSpec());
+
+      auto reshape_input_op = graph_ep->GetGraph()->CreateOperation<tim::vx::ops::Reshape>(std::vector<uint32_t>{first_dim, last_dim});
+      auto softmax_op = graph_ep->GetGraph()->CreateOperation<tim::vx::ops::Softmax>(1, 0);
+      auto reshaped_output_op = graph_ep->GetGraph()->CreateOperation<tim::vx::ops::Reshape>(inputs[0]->GetShape());
+
+      (*reshape_input_op).BindInputs(inputs).BindOutput(reshaped_input);
+      (*softmax_op).BindInput(reshaped_input).BindOutput(reshaped_output);
+      (*reshaped_output_op).BindInput(reshaped_output).BindOutput(outputs[0]);
+      graph_ep->GetOps().push_back(std::move(reshape_input_op));
+      graph_ep->GetOps().push_back(std::move(softmax_op));
+      graph_ep->GetOps().push_back(std::move(reshaped_output_op));
+    } else {
+      axis = HandleNegativeAxis(axis, inputs[0]->GetShape().size());
+      axis = inputs[0]->GetShape().size() - axis - 1;
+      auto op = graph_ep->GetGraph()->CreateOperation<tim::vx::ops::Softmax>(1, static_cast<uint32_t>(axis));
+      (*op).BindInputs(inputs).BindOutputs(outputs);
+      graph_ep->GetOps().push_back(std::move(op));
+    }
+    return true;
+  }
+};
+}  // namespace npu
+
+}  // namespace vsi
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/vsinpu/builders/impl/tensor_op_builder.h
+++ b/onnxruntime/core/providers/vsinpu/builders/impl/tensor_op_builder.h
@@ -1,0 +1,90 @@
+/****************************************************************************
+ *
+ *    Copyright (c) 2024 Vivante Corporation
+ *
+ *    Permission is hereby granted, free of charge, to any person obtaining a
+ *    copy of this software and associated documentation files (the "Software"),
+ *    to deal in the Software without restriction, including without limitation
+ *    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *    and/or sell copies of the Software, and to permit persons to whom the
+ *    Software is furnished to do so, subject to the following conditions:
+ *
+ *    The above copyright notice and this permission notice shall be included in
+ *    all copies or substantial portions of the Software.
+ *
+ *    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *    DEALINGS IN THE SOFTWARE.
+ *
+ *****************************************************************************/
+#include "core/providers/vsinpu/builders/impl/base_op_builder.h"
+#include "core/providers/shared/utils/utils.h"
+
+namespace onnxruntime {
+namespace vsi {
+namespace npu {
+class ReshapeOpBuilder : public BaseOpBuilder {
+  bool IsOpSupported(const onnxruntime::GraphViewer& graph_viewer,
+                     const Node* node) const override {
+    auto input_defs = node->InputDefs();
+    if (!graph_viewer.IsInitializedTensor(input_defs[1]->Name())) {
+      LOGS_DEFAULT(VERBOSE) << "New shape of reshape must be known";
+      return false;
+    }
+
+    NodeAttrHelper helper(*node);
+    const bool allow_zero = helper.Get("allowzero", 0) == 1;
+    auto& perm_tensor_proto = *graph_viewer.GetConstantInitializer(input_defs[1]->Name(), true);
+    std::vector<int64_t> perm(perm_tensor_proto.dims()[0]);
+    auto status = onnxruntime::utils::UnpackTensor(
+        perm_tensor_proto,
+        perm_tensor_proto.has_raw_data() ? perm_tensor_proto.raw_data().data() : nullptr,
+        perm_tensor_proto.has_raw_data() ? perm_tensor_proto.raw_data().size() : 0,
+        perm.data(), perm.size());
+
+    // Check if perm has any 0's when allow zero is enabled.
+    if (allow_zero && std::find(perm.begin(), perm.end(), 0L) != perm.end()) {
+      LOGS_DEFAULT(VERBOSE) << "Reshape doesn't support 0 as dimension when allowzero is enabled";
+      return false;
+    }
+
+    return true;
+  }
+  bool HandleBuildOp(vsi::npu::GraphEP* graph_ep,
+                     std::vector<std::shared_ptr<tim::vx::Tensor>>& inputs,
+                     std::vector<std::shared_ptr<tim::vx::Tensor>>& outputs,
+                     const Node* node) override {
+    LOGS_DEFAULT(VERBOSE) << "Creating Reshape Op.";
+    std::vector<int64_t> new_shape(inputs[1]->GetShape()[0]);
+    inputs[1]->CopyDataFromTensor(new_shape.data());
+    for (size_t i = 0; i < new_shape.size(); i++) {
+      if (new_shape[i] == 0) {
+        new_shape[i] = inputs[0]->GetShape()[inputs[0]->GetShape().size() - i - 1];
+      }
+    }
+
+    int64_t element_count = std::accumulate(new_shape.begin(), new_shape.end(), static_cast<int64_t>(1),
+                                            [&](int64_t a, int64_t b) {
+                                              return b == -1 ? a : a * b;
+                                            });
+    auto negative_it = std::find(new_shape.begin(), new_shape.end(), -1);
+    if (negative_it != new_shape.end()) {
+      *negative_it = inputs[0]->GetSpec().GetElementNum() / element_count;
+    }
+
+    std::vector<uint32_t> new_shape_uint32(new_shape.begin(), new_shape.end());
+    std::reverse(new_shape_uint32.begin(), new_shape_uint32.end());
+    auto op = graph_ep->GetGraph()->CreateOperation<tim::vx::ops::Reshape>(new_shape_uint32);
+    (*op).BindInput(inputs[0]).BindOutputs(outputs);
+    graph_ep->GetOps().push_back(std::move(op));
+    return true;
+  }
+};
+}  // namespace npu
+
+}  // namespace vsi
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/vsinpu/builders/op_builder_factory.h
+++ b/onnxruntime/core/providers/vsinpu/builders/op_builder_factory.h
@@ -31,6 +31,9 @@
 #include "impl/qlinearconv_op_builder.h"
 #include "impl/flatten_op_builder.h"
 #include "impl/matmul_op_builder.h"
+#include "impl/tensor_op_builder.h"
+#include "impl/concat_op_builder.h"
+#include "impl/softmax_op_builder.h"
 namespace onnxruntime {
 namespace vsi {
 namespace npu {
@@ -69,6 +72,9 @@ static const std::map<std::string, createIOpBuildItemFunc> reg = {
     REGISTER_OP_BUILDER("GlobalMaxPool", GlobalMaxPoolOpBuilder),
     REGISTER_OP_BUILDER("AveragePool", AveragePoolOpBuilder),
     REGISTER_OP_BUILDER("MaxPool", MaxPoolOpBuilder),
+    REGISTER_OP_BUILDER("Reshape", ReshapeOpBuilder),
+    REGISTER_OP_BUILDER("Concat", ConcatOpBuilder),
+    REGISTER_OP_BUILDER("Softmax", SoftmaxOpBuilder)
 
 #undef REGISTER_OP_BUILDER
 };

--- a/onnxruntime/core/providers/vsinpu/vsinpu_util.cc
+++ b/onnxruntime/core/providers/vsinpu/vsinpu_util.cc
@@ -64,6 +64,7 @@ tim::vx::DataType OnnxDtypeToTIMVXDtype(const ONNX_NAMESPACE::DataType type) {
       {"tensor(uint8)", tim::vx::DataType::UINT8},
       {"tensor(int32)", tim::vx::DataType::INT32},
       {"tensor(int16)", tim::vx::DataType::INT16},
+      {"tensor(int64)", tim::vx::DataType::INT64},
       {"tensor(bool)", tim::vx::DataType::INT8},
   };
   auto search = type_table.find(*type);


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Added Reshape/ Concat/Softmax ops



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- Perm is set as the second input of reshape, which is of int64 datatype, so int64 datatype must be supported


