### PR TITLE
Refine Op Binding && Add type limit of pow

### DIFF
--- a/onnxruntime/core/providers/vsinpu/builders/impl/activation_op_builder.h
+++ b/onnxruntime/core/providers/vsinpu/builders/impl/activation_op_builder.h
@@ -35,8 +35,8 @@ class ReluOpBuilder : public BaseOpBuilder {
                      const Node* node) override {
     LOGS_DEFAULT(VERBOSE) << "Creating Relu Activation.";
     auto op = graph_ep->GetGraph()->CreateOperation<tim::vx::ops::Relu>();
-    (*op).BindInputs(inputs).BindOutputs(outputs);
-    graph_ep->GetOps().push_back(std::move(op));
+    auto node_info = graph_ep->ConstructNodeIO(std::move(op), util::RemoveWrapper(node->InputDefs()), util::RemoveWrapper(node->OutputDefs()));
+    graph_ep->GetOps().push_back(node_info);
     return true;
   }
 };
@@ -48,8 +48,8 @@ class SigmoidOpBuilder : public BaseOpBuilder {
                      const Node* node) override {
     LOGS_DEFAULT(VERBOSE) << "Creating Sigmoid Activation.";
     auto op = graph_ep->GetGraph()->CreateOperation<tim::vx::ops::Sigmoid>();
-    (*op).BindInputs(inputs).BindOutputs(outputs);
-    graph_ep->GetOps().push_back(std::move(op));
+    auto node_info = graph_ep->ConstructNodeIO(std::move(op), util::RemoveWrapper(node->InputDefs()), util::RemoveWrapper(node->OutputDefs()));
+    graph_ep->GetOps().push_back(node_info);
     return true;
   }
 };
@@ -61,8 +61,8 @@ class TanhOpBuilder : public BaseOpBuilder {
                      const Node* node) override {
     LOGS_DEFAULT(VERBOSE) << "Creating Tanh activation.";
     auto op = graph_ep->GetGraph()->CreateOperation<tim::vx::ops::Tanh>();
-    (*op).BindInputs(inputs).BindOutputs(outputs);
-    graph_ep->GetOps().push_back(std::move(op));
+    auto node_info = graph_ep->ConstructNodeIO(std::move(op), util::RemoveWrapper(node->InputDefs()), util::RemoveWrapper(node->OutputDefs()));
+    graph_ep->GetOps().push_back(node_info);
     return true;
   }
 };
@@ -78,8 +78,8 @@ class LeakyReluOpBuilder : public BaseOpBuilder {
     auto alpha = helper.Get("alpha", 1.0f);
     auto op =
         graph_ep->GetGraph()->CreateOperation<tim::vx::ops::LeakyRelu>(alpha);
-    (*op).BindInputs(inputs).BindOutputs(outputs);
-    graph_ep->GetOps().push_back(std::move(op));
+    auto node_info = graph_ep->ConstructNodeIO(std::move(op), util::RemoveWrapper(node->InputDefs()), util::RemoveWrapper(node->OutputDefs()));
+    graph_ep->GetOps().push_back(node_info);
     return true;
   }
 };
@@ -95,8 +95,8 @@ class EluOpBuilder : public BaseOpBuilder {
     auto alpha = helper.Get("alpha", 1.0f);
     auto op =
         graph_ep->GetGraph()->CreateOperation<tim::vx::ops::LeakyRelu>(alpha);
-    (*op).BindInputs(inputs).BindOutputs(outputs);
-    graph_ep->GetOps().push_back(std::move(op));
+    auto node_info = graph_ep->ConstructNodeIO(std::move(op), util::RemoveWrapper(node->InputDefs()), util::RemoveWrapper(node->OutputDefs()));
+    graph_ep->GetOps().push_back(node_info);
     return true;
   }
 };
@@ -113,8 +113,8 @@ class HardSigmoidOpBuilder : public BaseOpBuilder {
     auto beta = helper.Get("beta", 1.0f);
     auto op = graph_ep->GetGraph()->CreateOperation<tim::vx::ops::HardSigmoid>(
         alpha, beta);
-    (*op).BindInputs(inputs).BindOutputs(outputs);
-    graph_ep->GetOps().push_back(std::move(op));
+    auto node_info = graph_ep->ConstructNodeIO(std::move(op), util::RemoveWrapper(node->InputDefs()), util::RemoveWrapper(node->OutputDefs()));
+    graph_ep->GetOps().push_back(node_info);
     return true;
   }
 };

--- a/onnxruntime/core/providers/vsinpu/builders/impl/concat_op_builder.h
+++ b/onnxruntime/core/providers/vsinpu/builders/impl/concat_op_builder.h
@@ -51,8 +51,8 @@ class ConcatOpBuilder : public BaseOpBuilder {
     auto axis = helper.Get("axis", 0);
     axis = util::ReverseAxis(axis, inputs[0]->GetShape().size());
     auto op = graph_ep->GetGraph()->CreateOperation<tim::vx::ops::Concat>(static_cast<uint32_t>(axis), inputs.size());
-    (*op).BindInputs(inputs).BindOutputs(outputs);
-    graph_ep->GetOps().push_back(std::move(op));
+    auto node_info = graph_ep->ConstructNodeIO(std::move(op), util::RemoveWrapper(node->InputDefs()), util::RemoveWrapper(node->OutputDefs()));
+    graph_ep->GetOps().push_back(node_info);
     return true;
   }
 };

--- a/onnxruntime/core/providers/vsinpu/builders/impl/conv_op_builder.h
+++ b/onnxruntime/core/providers/vsinpu/builders/impl/conv_op_builder.h
@@ -63,7 +63,7 @@ class ConvOpBuilder : public BaseOpBuilder {
                                          : default_vec);
     auto dilation =
         helper.Get("dilations", is_1d_conv ? std::vector<uint32_t>{default_uint}
-                                          : default_vec);
+                                           : default_vec);
 
     std::shared_ptr<tim::vx::Operation> op;
     if (padtype != "NOTSET") {  // array "pads" is not set
@@ -100,7 +100,7 @@ class ConvOpBuilder : public BaseOpBuilder {
         }
       }
     } else {
-      auto pads = helper.Get("pads", std::vector<uint32_t>{0U,0U});
+      auto pads = helper.Get("pads", std::vector<uint32_t>{0U, 0U});
       if (group != 1) {
         if (is_1d_conv) {
           op = graph_ep->GetGraph()
@@ -138,8 +138,8 @@ class ConvOpBuilder : public BaseOpBuilder {
         }
       }
     }
-    op->BindInputs(inputs).BindOutputs(outputs);
-    graph_ep->GetOps().push_back(std::move(op));
+    auto node_info = graph_ep->ConstructNodeIO(std::move(op), util::RemoveWrapper(node->InputDefs()), util::RemoveWrapper(node->OutputDefs()));
+    graph_ep->GetOps().push_back(node_info);
     return true;
   }
 };

--- a/onnxruntime/core/providers/vsinpu/builders/impl/elementwise_op_builder.h
+++ b/onnxruntime/core/providers/vsinpu/builders/impl/elementwise_op_builder.h
@@ -26,33 +26,78 @@
 namespace onnxruntime {
 namespace vsi {
 namespace npu {
-#define ELEMENTWISE_OP_BUILDER(onnx_op_type, vsinpu_op_kind)                   \
-  class onnx_op_type##OpBuilder : public BaseOpBuilder {                       \
-    bool HandleBuildOp(vsi::npu::GraphEP* graph_ep,                            \
-                       std::vector<std::shared_ptr<tim::vx::Tensor>>& inputs,  \
-                       std::vector<std::shared_ptr<tim::vx::Tensor>>& outputs, \
-                       const Node* node) override {                            \
-      LOGS_DEFAULT(INFO) << "Creating " << #onnx_op_type << " Op";             \
-      auto op = graph_ep->GetGraph()                                           \
-                    ->CreateOperation<tim::vx::ops::vsinpu_op_kind>();         \
-      (*op).BindInputs(inputs).BindOutputs(outputs);                           \
-      graph_ep->GetOps().push_back(std::move(op));                             \
-      return true;                                                             \
-      ;                                                                        \
-    }                                                                          \
+#define ELEMENTWISE_OP_BUILDER(onnx_op_type, vsinpu_op_kind)                                                       \
+  class onnx_op_type##OpBuilder : public BaseOpBuilder {                                                           \
+    bool IsOpSupported(const onnxruntime::GraphViewer& graph_viewer,                                               \
+                       const Node* node) const override {                                                          \
+      for (auto input : node->InputDefs()) {                                                                       \
+        if (*input->Type() == "tensor(int64)") {                                                                   \
+          LOGS_DEFAULT(WARNING) << "Int64 type is not suppoted as elementwise operation input.";                   \
+          return false;                                                                                            \
+        }                                                                                                          \
+      }                                                                                                            \
+      return true;                                                                                                 \
+    }                                                                                                              \
+    bool HandleBuildOp(vsi::npu::GraphEP* graph_ep,                                                                \
+                       std::vector<std::shared_ptr<tim::vx::Tensor>>& inputs,                                      \
+                       std::vector<std::shared_ptr<tim::vx::Tensor>>& outputs,                                     \
+                       const Node* node) override {                                                                \
+      LOGS_DEFAULT(INFO) << "Creating " << #onnx_op_type << " Op";                                                 \
+      auto op = graph_ep->GetGraph()                                                                               \
+                    ->CreateOperation<tim::vx::ops::vsinpu_op_kind>();                                             \
+      (*op).BindInputs(inputs).BindOutputs(outputs);                                                               \
+      auto node_info = graph_ep->ConstructNodeIO(std::move(op), std::vector<NodeArg*>(), std::vector<NodeArg*>()); \
+      graph_ep->GetOps().push_back(node_info);                                                                     \
+      return true;                                                                                                 \
+      ;                                                                                                            \
+    }                                                                                                              \
   };
+
 ELEMENTWISE_OP_BUILDER(Add, Add);
 ELEMENTWISE_OP_BUILDER(Sub, Sub);
 ELEMENTWISE_OP_BUILDER(Mul, Multiply);
 ELEMENTWISE_OP_BUILDER(Div, Div);  // not consider zero
 ELEMENTWISE_OP_BUILDER(Abs, Abs);
-ELEMENTWISE_OP_BUILDER(Pow, Pow);
 ELEMENTWISE_OP_BUILDER(Sqrt, Sqrt);
 ELEMENTWISE_OP_BUILDER(Exp, Exp);
 ELEMENTWISE_OP_BUILDER(Floor, Floor);
 ELEMENTWISE_OP_BUILDER(Log, Log);
 ELEMENTWISE_OP_BUILDER(Sin, Sin);
 ELEMENTWISE_OP_BUILDER(HardSwish, HardSwish);
+
+class PowOpBuilder : public BaseOpBuilder {
+  bool IsOpSupported(const onnxruntime::GraphViewer& graph_viewer,
+                     const Node* node) const override {
+    auto input0_type = *node->InputDefs()[0]->Type();
+    auto input1_type = *node->InputDefs()[1]->Type();
+
+    if (input0_type == "tensor(int64)" || input1_type == ("tensor(int64)")) {
+      LOGS_DEFAULT(WARNING) << "Int64 type is not suppoted as elementwise operation input.";
+      return false;
+    }
+    if (input0_type != input1_type) {
+      if ((input0_type == "tensor(float)" && input1_type == "tensor(int32)") || (input0_type == "tensor(int32)" && input1_type == "tensor(float)")) {
+        LOGS_DEFAULT(WARNING) << "Pow op does not support one of input is float32 while the other one is int32 type.";
+        return false;
+      }
+    }
+    return true;
+  }
+  bool HandleBuildOp(vsi::npu::GraphEP* graph_ep,
+                     std::vector<std::shared_ptr<tim::vx::Tensor>>& inputs,
+                     std::vector<std::shared_ptr<tim::vx::Tensor>>& outputs,
+                     const Node* node) override {
+    LOGS_DEFAULT(INFO) << "Creating Pow Op";
+    auto op = graph_ep->GetGraph()
+                  ->CreateOperation<tim::vx::ops::Pow>();
+    (*op).BindInputs(inputs).BindOutputs(outputs);
+    auto node_info = graph_ep->ConstructNodeIO(std::move(op), std::vector<NodeArg*>(), std::vector<NodeArg*>());
+    graph_ep->GetOps().push_back(node_info);
+    return true;
+    ;
+  }
+};
+
 }  // namespace npu
 
 }  // namespace vsi

--- a/onnxruntime/core/providers/vsinpu/builders/impl/flatten_op_builder.h
+++ b/onnxruntime/core/providers/vsinpu/builders/impl/flatten_op_builder.h
@@ -51,8 +51,8 @@ class FlattenOpBuilder : public BaseOpBuilder {
       reshape_param.push_back(second_dim);
     }
     auto op = graph_ep->GetGraph()->CreateOperation<tim::vx::ops::Reshape>(reshape_param);
-    (*op).BindInput(inputs[0]).BindOutput(outputs[0]);
-    graph_ep->GetOps().push_back(std::move(op));
+    auto node_info = graph_ep->ConstructNodeIO(std::move(op), util::RemoveWrapper(node->InputDefs()), util::RemoveWrapper(node->OutputDefs()));
+    graph_ep->GetOps().push_back(node_info);
     return true;
   }
 };

--- a/onnxruntime/core/providers/vsinpu/builders/impl/matmul_op_builder.h
+++ b/onnxruntime/core/providers/vsinpu/builders/impl/matmul_op_builder.h
@@ -34,6 +34,12 @@ class MatMulOpBuilder : public BaseOpBuilder {
       LOGS_DEFAULT(ERROR) << "Inner product of 1-D tensor is not supported in MatMul op.";
       return false;
     }
+    for(auto input : node ->InputDefs()){
+      if(*input->Type() == "tensor(int64)") {
+        LOGS_DEFAULT(WARNING) << "Cannot support int64 Gemm operation.";
+        return false;
+      }
+    }
     return true;
   }
   bool HandleBuildOp(vsi::npu::GraphEP* graph_ep,
@@ -42,8 +48,8 @@ class MatMulOpBuilder : public BaseOpBuilder {
                      const Node* node) override {
     LOGS_DEFAULT(VERBOSE) << "Creating Matmul Op.";
     auto op = graph_ep->GetGraph()->CreateOperation<tim::vx::ops::Matmul>();
-    (*op).BindInputs(inputs).BindOutputs(outputs);
-    graph_ep->GetOps().push_back(std::move(op));
+    auto node_info = graph_ep->ConstructNodeIO(std::move(op), util::RemoveWrapper(node->InputDefs()), util::RemoveWrapper(node->OutputDefs()));
+    graph_ep->GetOps().push_back(node_info);
     return true;
   }
 };

--- a/onnxruntime/core/providers/vsinpu/builders/impl/norm_op_builder.h
+++ b/onnxruntime/core/providers/vsinpu/builders/impl/norm_op_builder.h
@@ -63,9 +63,14 @@ class BatchNormOpBuilder : public BaseOpBuilder {
     NodeAttrHelper helper(*node);
     auto epsilon = helper.Get("epsilon", 1e-5f);
     auto op = graph_ep->GetGraph()->CreateOperation<tim::vx::ops::BatchNorm>(epsilon);
-    (*op).BindInput(inputs[input_tensor]).BindInput(inputs[mean_tensor]).BindInput(inputs[var_tensor]).BindInput(inputs[scale_tensor]).BindInput(inputs[Bias_tensor]);
-    (*op).BindOutputs(outputs);
-    graph_ep->GetOps().push_back(std::move(op));
+    std::vector<NodeArg*> input_defs;
+    int indices[] = {input_tensor, mean_tensor, var_tensor, scale_tensor, Bias_tensor};
+    for (int i : indices) {
+      input_defs.push_back(util::RemoveWrapper(node->InputDefs()[i]));
+    }
+
+    auto node_info = graph_ep->ConstructNodeIO(std::move(op), input_defs, util::RemoveWrapper(node->OutputDefs()));
+    graph_ep->GetOps().push_back(node_info);
     return true;
   }
 };

--- a/onnxruntime/core/providers/vsinpu/builders/impl/qlinearmatmul_op_builder.h
+++ b/onnxruntime/core/providers/vsinpu/builders/impl/qlinearmatmul_op_builder.h
@@ -55,7 +55,7 @@ class QLinearMatMulOpBuilder : public BaseOpBuilder {
     }
 
     if (input_defs[A_scale]->Shape()->dim_size() != 1 || input_defs[B_scale]->Shape()->dim_size() != 1 || input_defs[out_scale]->Shape()->dim_size() != 1) {
-      LOGS_DEFAULT(ERROR) << "Per channel quantized output is not supported in QuantizeLinearOp.";
+      LOGS_DEFAULT(ERROR) << "Per channel quantized input/output is not supported in QuantizeLinearOp.";
       return false;
     }
 

--- a/onnxruntime/core/providers/vsinpu/builders/impl/reduce_op_builder.h
+++ b/onnxruntime/core/providers/vsinpu/builders/impl/reduce_op_builder.h
@@ -68,8 +68,10 @@ class ReduceMeanOpBuilder : public BaseOpBuilder {
 
     bool keepdims = helper.Get("keepdims", 1) == 1;
     auto op = graph_ep->GetGraph()->CreateOperation<tim::vx::ops::ReduceMean>(axes, keepdims);
-    op->BindInput(inputs[0]).BindOutputs(outputs);
-    graph_ep->GetOps().push_back(std::move(op));
+    std::vector<NodeArg*> input_defs;
+    input_defs.push_back(util::RemoveWrapper(node->InputDefs()[0]));
+    auto node_info = graph_ep->ConstructNodeIO(std::move(op), input_defs, util::RemoveWrapper(node->OutputDefs()));
+    graph_ep->GetOps().push_back(node_info);
 
     return true;
 }

--- a/onnxruntime/core/providers/vsinpu/builders/impl/tensor_op_builder.h
+++ b/onnxruntime/core/providers/vsinpu/builders/impl/tensor_op_builder.h
@@ -79,8 +79,10 @@ class ReshapeOpBuilder : public BaseOpBuilder {
     std::vector<uint32_t> new_shape_uint32(new_shape.begin(), new_shape.end());
     std::reverse(new_shape_uint32.begin(), new_shape_uint32.end());
     auto op = graph_ep->GetGraph()->CreateOperation<tim::vx::ops::Reshape>(new_shape_uint32);
-    (*op).BindInput(inputs[0]).BindOutputs(outputs);
-    graph_ep->GetOps().push_back(std::move(op));
+    std::vector<NodeArg*> input_defs;
+    input_defs.push_back(util::RemoveWrapper(node->InputDefs()[0]));
+    auto node_info = graph_ep->ConstructNodeIO(std::move(op), input_defs, util::RemoveWrapper(node->OutputDefs()));
+    graph_ep->GetOps().push_back(node_info);
     return true;
   }
 };
@@ -117,8 +119,8 @@ class TransposeOpBuilder : public BaseOpBuilder {
       timvx_perm.push_back(def_val.size() - 1 - def_val[def_val.size() - i - 1]);
     }
     auto op = graph_ep->GetGraph()->CreateOperation<tim::vx::ops::Transpose>(timvx_perm);
-    (*op).BindInputs(inputs).BindOutputs(outputs);
-    graph_ep->GetOps().push_back(std::move(op));
+    auto node_info = graph_ep->ConstructNodeIO(std::move(op), util::RemoveWrapper(node->InputDefs()), util::RemoveWrapper(node->OutputDefs()));
+    graph_ep->GetOps().push_back(node_info);
     return true;
   }
 };

--- a/onnxruntime/core/providers/vsinpu/vsinpu_ep_graph.cc
+++ b/onnxruntime/core/providers/vsinpu/vsinpu_ep_graph.cc
@@ -49,6 +49,78 @@ bool GraphEP::SupportedOp(const onnxruntime::GraphViewer& graph_viewer,
   return false;
 }
 
+void GraphEP::UpdateTensorMap(std::string name, std::shared_ptr<tim::vx::Tensor> dst_tensor) {
+  auto it = tensors_.find(name);
+  if (it != tensors_.end()) {
+    it->second = dst_tensor;
+  }
+  for (auto& IO : graph_inputs_) {
+    if (IO->name == name) {
+      IO->tensor = dst_tensor;
+      break;
+    }
+  }
+  for (auto& IO : graph_outputs_) {
+    if (IO->name == name) {
+      IO->tensor = dst_tensor;
+      break;
+    }
+  }
+}
+
+std::shared_ptr<NodeIOInfo> GraphEP::ConstructNodeIO(const std::shared_ptr<tim::vx::Operation>& op, std::vector<NodeArg*> input_arg, std::vector<NodeArg*> output_arg) {
+  auto info = std::make_shared<vsi::npu::NodeIOInfo>();
+  info->op_ = op;
+  std::vector<std::string> input_names, output_names;
+  if (input_arg.empty()) {
+    info->input_names_ = std::vector<std::string>();
+  } else {
+    input_names.reserve(input_arg.size());
+    std::transform(input_arg.begin(), input_arg.end(), std::back_inserter(input_names),
+                   [](const NodeArg* node) -> std::string {
+                     return node->Name();
+                   });
+    info->input_names_ = input_names;
+  }
+  if (output_arg.empty()) {
+    info->output_names_ = std::vector<std::string>();
+  } else {
+    output_names.reserve(output_arg.size());
+    std::transform(output_arg.begin(), output_arg.end(), std::back_inserter(output_names),
+                   [](const NodeArg* node) -> std::string {
+                     return node->Name();
+                   });
+    info->output_names_ = output_names;
+  }
+
+  return info;
+}
+
+bool GraphEP::BindTensors(const std::shared_ptr<NodeIOInfo>& nodeio_info) {
+  auto op = nodeio_info->op_;
+  auto input_names = nodeio_info->input_names_;
+  auto output_names = nodeio_info->output_names_;
+  if (!input_names.empty()) {
+    for (auto name : input_names) {
+      if (tensors_.find(name) == tensors_.end() || tensors_[name] == nullptr) {
+        LOGS_DEFAULT(ERROR) << "Input tensor not defined or not found!";
+        return false;
+      }
+      (*op).BindInput(tensors_[name]);
+    }
+  }
+  if (!output_names.empty()) {
+    for (auto name : output_names) {
+      if (tensors_.find(name) == tensors_.end() || tensors_[name] == nullptr) {
+        LOGS_DEFAULT(ERROR) << "Output tensor not defined or not found!";
+        return false;
+      }
+      (*op).BindOutput(tensors_[name]);
+    }
+  }
+  return true;
+}
+
 std::shared_ptr<tim::vx::Tensor> GraphEP::MapTIMVXTensor(
     std::shared_ptr<tim::vx::Graph>& graph, const NodeArg* arg,
     const GraphViewer* graph_viewer, tim::vx::TensorAttribute attribute) {

--- a/onnxruntime/core/providers/vsinpu/vsinpu_ep_graph.h
+++ b/onnxruntime/core/providers/vsinpu/vsinpu_ep_graph.h
@@ -42,6 +42,12 @@ struct GraphIOInfo {
   TensorShape shape;
 };
 
+struct NodeIOInfo {
+  std::shared_ptr<tim::vx::Operation> op_;
+  std::vector<std::string> input_names_;
+  std::vector<std::string> output_names_;
+};
+
 class GraphEP {
  public:
   explicit GraphEP();
@@ -50,7 +56,7 @@ class GraphEP {
                           const Node* node);
   bool& GetCompiled() { return compiled_; }
   std::shared_ptr<tim::vx::Graph>& GetGraph() { return graph_; }
-  std::vector<std::shared_ptr<tim::vx::Operation>>& GetOps() { return ops_; }
+  std::vector<std::shared_ptr<NodeIOInfo>>& GetOps() { return ops_; }
   std::map<std::string, std::shared_ptr<tim::vx::Tensor>>& GetTensors() {
     return tensors_;
   }
@@ -63,6 +69,12 @@ class GraphEP {
     return graph_outputs_;
   };
 
+  void UpdateTensorMap(std::string name, std::shared_ptr<tim::vx::Tensor> dst_tensor);
+
+  std::shared_ptr<NodeIOInfo> ConstructNodeIO(const std::shared_ptr<tim::vx::Operation>& op, std::vector<NodeArg*>input_arg, std::vector<NodeArg*>output_arg);
+
+  bool BindTensors(const std::shared_ptr<NodeIOInfo>& nodeio_info);
+
   std::shared_ptr<tim::vx::Tensor> MapTIMVXTensor(
       std::shared_ptr<tim::vx::Graph>& graph, const NodeArg* arg,
       const GraphViewer* graph_viewer, tim::vx::TensorAttribute attribute);
@@ -71,7 +83,7 @@ class GraphEP {
   std::shared_ptr<tim::vx::Context> context_;
   std::shared_ptr<tim::vx::Graph> graph_;
   std::map<std::string, std::shared_ptr<tim::vx::Tensor>> tensors_;
-  std::vector<std::shared_ptr<tim::vx::Operation>> ops_;
+  std::vector<std::shared_ptr<NodeIOInfo>> ops_;
   std::vector<std::shared_ptr<GraphIOInfo>> graph_inputs_;
   std::vector<std::shared_ptr<GraphIOInfo>> graph_outputs_;
   bool compiled_;

--- a/onnxruntime/core/providers/vsinpu/vsinpu_execution_provider.cc
+++ b/onnxruntime/core/providers/vsinpu/vsinpu_execution_provider.cc
@@ -371,6 +371,14 @@ Status VSINPUExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& fu
       vsi::npu::SupportedBuiltinOps().at(node->OpType())->BuildOp(graph_ep.get(), graph_viewer, node);
     }
 
+    for (const auto& node_info : graph_ep->GetOps()) {
+      if (node_info->input_names_.empty() && node_info->output_names_.empty())
+        continue;
+      else {
+        graph_ep->BindTensors(node_info);
+      }
+    }
+
     LOGS_DEFAULT(INFO) << "Verifying graph";
     graph_ep->GetCompiled() = graph_ep->GetGraph()->Compile();
     if (!graph_ep->GetCompiled()) {

--- a/onnxruntime/core/providers/vsinpu/vsinpu_util.cc
+++ b/onnxruntime/core/providers/vsinpu/vsinpu_util.cc
@@ -92,10 +92,14 @@ tim::vx::ShapeType OnnxShapeToTIMVXShape(const onnxruntime::TensorShape ts) {
 
 std::string PrintNode(const onnxruntime::NodeArg& node_arg) {
   auto shape = node_arg.Shape();
-  if (shape == nullptr || shape->dim_size() == 0) {
+  if (shape == nullptr) {
     return "<null>";
   }
   std::string s = node_arg.Name() + ":<";
+  if (shape->dim_size() == 0) {
+    s += "1>, is a scalar";
+    return s;
+  }
   for (int i = 0; i < shape->dim_size(); i++) {
     auto dim = shape->dim(i);
     std::string s1;
@@ -305,6 +309,18 @@ std::vector<int32_t> ReverseAxis(std::vector<int32_t> origin_axes, int32_t lengt
   }
   std::sort(axes.begin(), axes.end());
   return axes;
+}
+
+std::vector<NodeArg*> RemoveWrapper(ConstPointerContainer<std::vector<NodeArg*>> constPtrContainer) {
+  std::vector<onnxruntime::NodeArg*> nodeArgsVector;
+  for (const auto& nodeArgPtr : constPtrContainer) {
+    nodeArgsVector.push_back(const_cast<onnxruntime::NodeArg*>(nodeArgPtr));
+  }
+  return nodeArgsVector;
+}
+
+NodeArg* RemoveWrapper(const NodeArg* onnxNodeArg){
+  return const_cast<NodeArg*> (onnxNodeArg);
 }
 
 }  // namespace util

--- a/onnxruntime/core/providers/vsinpu/vsinpu_util.h
+++ b/onnxruntime/core/providers/vsinpu/vsinpu_util.h
@@ -73,6 +73,9 @@ int32_t ReverseAxis(int32_t origin_axis, int32_t length);
 
 std::vector<int32_t> ReverseAxis(std::vector<int32_t> origin_axes, int32_t length);
 
+std::vector<NodeArg*> RemoveWrapper(ConstPointerContainer<std::vector<NodeArg*>> constContainer);
+NodeArg* RemoveWrapper(const NodeArg* onnxNodeArg);
+
 }  // namespace util
 }  // namespace npu
 }  // namespace vsi


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- Code Refine: HandleBuildOp and ep Compile
- Bugfix of Pow op
- Added scalar input descriprion



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- Ops will be built in builder's HandleBuildOp func, but not bind tensors until all ops are established done.Tensors can be easily updated by UpdateTensorMap api
- Pow op does not support float+int32 type input
- Scalar tensor is described as null in printing graph process


