### PR TITLE
Added depthwise support and local testing scripts

### DIFF
--- a/hack_for_testing.patch
+++ b/hack_for_testing.patch
@@ -1,0 +1,343 @@
+diff --git a/onnxruntime/test/onnx/dataitem_request.cc b/onnxruntime/test/onnx/dataitem_request.cc
+index 1ee302d5d5..5c2dd5ab00 100644
+--- a/onnxruntime/test/onnx/dataitem_request.cc
++++ b/onnxruntime/test/onnx/dataitem_request.cc
+@@ -135,6 +135,7 @@ std::pair<EXECUTE_RESULT, TIME_SPEC> DataTaskRequestContext::RunImpl() {
+   }
+ 
+   EXECUTE_RESULT res = EXECUTE_RESULT::SUCCESS;
++  int32_t out_idx = 0;
+   for (auto& output : expected_output_values) {
+     const std::string& output_name = output.first;
+     OrtValue* expected_output_value = output.second;  // Automatic cast
+@@ -170,7 +171,7 @@ std::pair<EXECUTE_RESULT, TIME_SPEC> DataTaskRequestContext::RunImpl() {
+       } else {  // Both expect and actual OrtValues are not None, proceed with data checking
+         ret =
+             CompareOrtValue(*actual_output_value, *expected_output_value, per_sample_tolerance,
+-                            relative_per_sample_tolerance, post_procesing);
++                            relative_per_sample_tolerance, post_procesing, out_idx);
+       }
+     } else {  // Expected output is None, ensure that the received output OrtValue is None as well
+       if (actual_output_value->IsAllocated()) {
+@@ -223,9 +224,10 @@ std::pair<EXECUTE_RESULT, TIME_SPEC> DataTaskRequestContext::RunImpl() {
+     if (compare_result != COMPARE_RESULT::SUCCESS && !ret.second.empty()) {
+       LOGS_DEFAULT(ERROR) << test_case_.GetTestCaseName() << ":output=" << output_name << ":" << ret.second;
+     }
+-    if (compare_result != COMPARE_RESULT::SUCCESS) {
+-      break;
+-    }
++    // if (compare_result != COMPARE_RESULT::SUCCESS) {
++    //   break;
++    // }
++    out_idx ++;
+   }
+   return std::make_pair(res, spent_time_);
+ }
+diff --git a/onnxruntime/test/providers/checkers.cc b/onnxruntime/test/providers/checkers.cc
+index f1a7240ea3..436031dfa8 100644
+--- a/onnxruntime/test/providers/checkers.cc
++++ b/onnxruntime/test/providers/checkers.cc
+@@ -154,6 +154,7 @@ struct TensorCheck<int8_t> {
+     }
+ 
+     const bool has_abs_err = params.absolute_error.has_value();
++    const int8_t default_abs_err = 1;
+     if (has_abs_err) {
+       double threshold = *(params.absolute_error);
+ 
+@@ -162,7 +163,8 @@ struct TensorCheck<int8_t> {
+       }
+     } else {
+       for (int i = 0; i < size; ++i) {
+-        EXPECT_EQ(cur_expected[i], cur_actual[i]) << "i:" << i;
++        // EXPECT_EQ(cur_expected[i], cur_actual[i]) << "i:" << i;
++        EXPECT_NEAR(cur_expected[i], cur_actual[i], default_abs_err) << "i:" << i;
+       }
+     }
+   }
+diff --git a/onnxruntime/test/util/compare_ortvalue.cc b/onnxruntime/test/util/compare_ortvalue.cc
+index 3d53d4a3a0..8129af1820 100644
+--- a/onnxruntime/test/util/compare_ortvalue.cc
++++ b/onnxruntime/test/util/compare_ortvalue.cc
+@@ -138,11 +138,75 @@ std::pair<COMPARE_RESULT, std::string> CompareFloatResult(const Tensor& outvalue
+   return res;
+ }
+ 
++template <typename FLOAT_TYPE>
++std::pair<COMPARE_RESULT, std::string> CompareFloatResult(const Tensor& outvalue, const Tensor& expected_value,
++                                                          double per_sample_tolerance,
++                                                          double relative_per_sample_tolerance, bool post_processing, int32_t out_idx) {
++  const size_t size1 = static_cast<size_t>(expected_value.Shape().Size());
++  const FLOAT_TYPE* expected_output = expected_value.Data<FLOAT_TYPE>();
++  const FLOAT_TYPE* real_output = outvalue.Data<FLOAT_TYPE>();
++
++  std::string expected_name = "expected_res"+ std::to_string(out_idx)+ ".txt";
++  std::string npures_name = "npu_res"+ std::to_string(out_idx)+ ".txt";
++  std::ofstream expected_res(expected_name), npu_res(npures_name);
++  for(size_t i = 0 ; i < size1; i++){
++    expected_res << expected_output[i] << std::endl;
++    npu_res << real_output[i] << std::endl;
++  }
++  expected_res.close();
++  npu_res.close();
++
++  std::pair<COMPARE_RESULT, std::string> res = std::make_pair(COMPARE_RESULT::SUCCESS, "");
++  double max_diff = 0;
++  size_t diff_count = 0;
++  for (size_t di = 0; di != size1; ++di) {
++    const double real_value =
++        post_processing ? std::max<double>(0.0, std::min<double>(255.0, real_output[di])) : real_output[di];
++    const double diff = std::fabs(expected_output[di] - real_value);
++    const double tol = per_sample_tolerance + relative_per_sample_tolerance * std::fabs(expected_output[di]);
++    if (!IsResultCloselyMatch<double>(real_value, expected_output[di], diff, tol)) {
++      res.first = COMPARE_RESULT::RESULT_DIFFERS;
++      // update error message if this is a larger diff
++      if (diff > max_diff || (std::isnan(diff) && !std::isnan(max_diff))) {
++        int64_t expected_int = 0;
++        int64_t real_int = 0;
++        memcpy(&expected_int, &expected_output[di], sizeof(FLOAT_TYPE));
++        memcpy(&real_int, &real_output[di], sizeof(FLOAT_TYPE));
++
++        std::ostringstream oss;
++        oss << std::hex << "expected " << expected_output[di] << " (" << expected_int << "), got " << real_value << " ("
++            << real_int << ")"
++            << ", diff: " << diff << ", tol=" << tol << std::dec << " idx=" << di << ".";
++        res.second = oss.str();
++        max_diff = diff;
++      }
++      ++diff_count;
++    }
++  }
++
++  if (res.first == COMPARE_RESULT::SUCCESS) return res;
++
++  std::ostringstream oss;
++  oss << res.second << " " << diff_count << " of " << size1 << " differ";
++  res.second = oss.str();
++  return res;
++}
++
++
+ template <typename T>
+-std::pair<COMPARE_RESULT, std::string> IsResultExactlyMatch(const Tensor& outvalue, const Tensor& expected_value) {
++std::pair<COMPARE_RESULT, std::string> IsResultExactlyMatch(const Tensor& outvalue, const Tensor& expected_value, int32_t out_idx) {
+   const size_t size1 = static_cast<size_t>(expected_value.Shape().Size());
+   const T* expected_output = expected_value.Data<T>();
+   const T* real_output = outvalue.Data<T>();
++  std::string expected_name = "expected_res"+ std::to_string(out_idx)+ ".txt";
++  std::string npures_name = "npu_res"+ std::to_string(out_idx)+ ".txt";
++  std::ofstream expected_res(expected_name), npu_res(npures_name);
++  for(size_t i = 0 ; i < size1; i++){
++    expected_res << expected_output[i] << std::endl;
++    npu_res << real_output[i] << std::endl;
++  }
++  expected_res.close();
++  npu_res.close();
+   for (size_t di = 0; di != size1; ++di) {
+     if (expected_output[di] != real_output[di]) {
+       std::ostringstream oss;
+@@ -201,7 +265,7 @@ std::pair<COMPARE_RESULT, std::string> CompareBFloat16Result(const Tensor& outva
+ 
+ std::pair<COMPARE_RESULT, std::string> CompareTwoTensors(const Tensor& outvalue, const Tensor& expected_tensor,
+                                                          double per_sample_tolerance,
+-                                                         double relative_per_sample_tolerance, bool post_processing) {
++                                                         double relative_per_sample_tolerance, bool post_processing, int32_t out_idx) {
+   if (expected_tensor.Shape() != outvalue.Shape()) {
+     std::ostringstream oss;
+     oss << "shape mismatch, expect " << expected_tensor.Shape().ToString() << " got " << outvalue.Shape().ToString();
+@@ -209,30 +273,30 @@ std::pair<COMPARE_RESULT, std::string> CompareTwoTensors(const Tensor& outvalue,
+   }
+   if (outvalue.IsDataType<float>()) {
+     return CompareFloatResult<float>(outvalue, expected_tensor, per_sample_tolerance, relative_per_sample_tolerance,
+-                                     post_processing);
++                                     post_processing, out_idx);
+   } else if (outvalue.IsDataType<double>()) {
+     return CompareFloatResult<double>(outvalue, expected_tensor, per_sample_tolerance, relative_per_sample_tolerance,
+-                                      post_processing);
++                                      post_processing, out_idx);
+   } else if (outvalue.IsDataTypeString()) {
+-    return IsResultExactlyMatch<std::string>(outvalue, expected_tensor);
++    return IsResultExactlyMatch<std::string>(outvalue, expected_tensor, out_idx);
+   } else if (outvalue.IsDataType<uint8_t>()) {
+-    return IsResultExactlyMatch<uint8_t>(outvalue, expected_tensor);
++    return IsResultExactlyMatch<uint8_t>(outvalue, expected_tensor, out_idx);
+   } else if (outvalue.IsDataType<int8_t>()) {
+-    return IsResultExactlyMatch<int8_t>(outvalue, expected_tensor);
++    return IsResultExactlyMatch<int8_t>(outvalue, expected_tensor, out_idx);
+   } else if (outvalue.IsDataType<uint16_t>()) {
+-    return IsResultExactlyMatch<uint16_t>(outvalue, expected_tensor);
++    return IsResultExactlyMatch<uint16_t>(outvalue, expected_tensor, out_idx);
+   } else if (outvalue.IsDataType<int16_t>()) {
+-    return IsResultExactlyMatch<int16_t>(outvalue, expected_tensor);
++    return IsResultExactlyMatch<int16_t>(outvalue, expected_tensor, out_idx);
+   } else if (outvalue.IsDataType<uint32_t>()) {
+-    return IsResultExactlyMatch<uint32_t>(outvalue, expected_tensor);
++    return IsResultExactlyMatch<uint32_t>(outvalue, expected_tensor, out_idx);
+   } else if (outvalue.IsDataType<int32_t>()) {
+-    return IsResultExactlyMatch<int32_t>(outvalue, expected_tensor);
++    return IsResultExactlyMatch<int32_t>(outvalue, expected_tensor, out_idx);
+   } else if (outvalue.IsDataType<uint64_t>()) {
+-    return IsResultExactlyMatch<uint64_t>(outvalue, expected_tensor);
++    return IsResultExactlyMatch<uint64_t>(outvalue, expected_tensor, out_idx);
+   } else if (outvalue.IsDataType<int64_t>()) {
+-    return IsResultExactlyMatch<int64_t>(outvalue, expected_tensor);
++    return IsResultExactlyMatch<int64_t>(outvalue, expected_tensor, out_idx);
+   } else if (outvalue.IsDataType<bool>()) {
+-    return IsResultExactlyMatch<bool>(outvalue, expected_tensor);
++    return IsResultExactlyMatch<bool>(outvalue, expected_tensor, out_idx);
+   } else if (outvalue.IsDataType<MLFloat16>()) {
+     return CompareFloat16Result(outvalue, expected_tensor, per_sample_tolerance, relative_per_sample_tolerance,
+                                 post_processing);
+@@ -300,7 +364,7 @@ std::pair<COMPARE_RESULT, std::string> CompareSparseTensors(const SparseTensor&
+                      " actual: ", actual.Format());
+ 
+   TEST_RETURN_IF_ERROR(CompareTwoTensors(actual.Values(), expected.Values(),
+-                                         per_sample_tolerance, relative_per_sample_tolerance, post_processing),
++                                         per_sample_tolerance, relative_per_sample_tolerance, post_processing, 0),
+                        "While comparing sparse values");
+ 
+   if (actual.Format() == SparseFormat::kCoo) {
+@@ -308,16 +372,16 @@ std::pair<COMPARE_RESULT, std::string> CompareSparseTensors(const SparseTensor&
+     auto expected_view = expected.AsCoo();
+ 
+     TEST_RETURN_IF_ERROR(CompareTwoTensors(actual_view.Indices(), expected_view.Indices(),
+-                                           per_sample_tolerance, relative_per_sample_tolerance, post_processing),
++                                           per_sample_tolerance, relative_per_sample_tolerance, post_processing, 0),
+                          "Comparing COO indices");
+   } else if (actual.Format() == SparseFormat::kCsrc) {
+     auto actual_view = actual.AsCsr();
+     auto expected_view = expected.AsCsr();
+     TEST_RETURN_IF_ERROR(CompareTwoTensors(actual_view.Inner(), expected_view.Inner(),
+-                                           per_sample_tolerance, relative_per_sample_tolerance, post_processing),
++                                           per_sample_tolerance, relative_per_sample_tolerance, post_processing, 0),
+                          "Comparing Csr(c) inner indices");
+     TEST_RETURN_IF_ERROR(CompareTwoTensors(actual_view.Outer(), expected_view.Outer(),
+-                                           per_sample_tolerance, relative_per_sample_tolerance, post_processing),
++                                           per_sample_tolerance, relative_per_sample_tolerance, post_processing, 0),
+                          "Comparing Csr(c) outer indices");
+   }
+ 
+@@ -385,7 +449,83 @@ std::pair<COMPARE_RESULT, std::string> CompareOrtValue(const OrtValue& o, const
+       return std::make_pair(COMPARE_RESULT::TYPE_MISMATCH, oss.str());
+     }
+     return CompareTwoTensors(outvalue, expected_tensor, per_sample_tolerance, relative_per_sample_tolerance,
+-                             post_processing);
++                             post_processing, 0);
++  } else if (o.IsSparseTensor()) {
++#if !defined(DISABLE_SPARSE_TENSORS)
++    TEST_RETURN_IF_NOT(expected_mlvalue.IsSparseTensor(), COMPARE_RESULT::TYPE_MISMATCH,
++                       "SparseTensor is not expected as output");
++    TEST_RETURN_IF_ERROR(CompareSparseTensors(o.Get<SparseTensor>(), expected_mlvalue.Get<SparseTensor>(),
++                                              per_sample_tolerance, relative_per_sample_tolerance,
++                                              post_processing),
++                         "while comaring sparse tensors");
++#endif
++    return std::make_pair(COMPARE_RESULT::SUCCESS, "");
++  } else if (o.IsTensorSequence()) {
++    auto& expected_tensor_seq = expected_mlvalue.Get<TensorSeq>();
++    auto expected_tensor_count = expected_tensor_seq.Size();
++
++    auto& actual_tensor_seq = o.Get<TensorSeq>();
++    auto actual_tensor_count = actual_tensor_seq.Size();
++
++    if (expected_tensor_count != actual_tensor_count) {
++      std::ostringstream oss;
++      oss << "expected tensor count in the sequence: " << expected_tensor_count << " got "
++          << actual_tensor_count;
++      return std::make_pair(COMPARE_RESULT::RESULT_DIFFERS, oss.str());
++    }
++
++    if (!expected_tensor_seq.IsSameDataType(actual_tensor_seq)) {
++      std::ostringstream oss;
++      oss << "expected tensor type in the sequence: " << expected_tensor_seq.DataType() << " got "
++          << actual_tensor_seq.DataType();
++      return std::make_pair(COMPARE_RESULT::TYPE_MISMATCH, oss.str());
++    }
++
++    for (size_t i = 0; i < expected_tensor_count; ++i) {
++      auto res = CompareTwoTensors(actual_tensor_seq.Get(i), expected_tensor_seq.Get(i), per_sample_tolerance, relative_per_sample_tolerance,
++                                   post_processing,0);
++      if (res.first != COMPARE_RESULT::SUCCESS) {
++        return res;
++      }
++    }
++
++    return std::make_pair(COMPARE_RESULT::SUCCESS, "");
++
++  } else {
++    // Maps
++#if !defined(DISABLE_ML_OPS)
++    if (o.Type() == DataTypeImpl::GetType<VectorMapInt64ToFloat>()) {
++      return CompareSeqOfMapToFloat(o.Get<VectorMapInt64ToFloat>(), expected_mlvalue.Get<VectorMapInt64ToFloat>(),
++                                    per_sample_tolerance, relative_per_sample_tolerance, post_processing);
++    }
++    if (o.Type() == DataTypeImpl::GetType<VectorMapStringToFloat>()) {
++      return CompareSeqOfMapToFloat(o.Get<VectorMapStringToFloat>(), expected_mlvalue.Get<VectorMapStringToFloat>(),
++                                    per_sample_tolerance, relative_per_sample_tolerance, post_processing);
++    }
++    return std::make_pair(COMPARE_RESULT::NOT_SUPPORT, "");
++#else
++    return std::make_pair(COMPARE_RESULT::NOT_SUPPORT, "Map type is not supported in this build.");
++#endif
++  }
++}
++
++std::pair<COMPARE_RESULT, std::string> CompareOrtValue(const OrtValue& o, const OrtValue& expected_mlvalue,
++                                                       double per_sample_tolerance,
++                                                       double relative_per_sample_tolerance, bool post_processing, int32_t out_idx) {
++  if (o.Type() != expected_mlvalue.Type()) {
++    return std::make_pair(COMPARE_RESULT::TYPE_MISMATCH, "");
++  }
++  if (o.IsTensor()) {
++    const Tensor& outvalue = o.Get<Tensor>();
++    const Tensor& expected_tensor = expected_mlvalue.Get<Tensor>();
++    if (outvalue.DataType() != expected_tensor.DataType()) {
++      std::ostringstream oss;
++      oss << "expect " << ElementTypeToString(expected_tensor.DataType()) << " got "
++          << ElementTypeToString(outvalue.DataType());
++      return std::make_pair(COMPARE_RESULT::TYPE_MISMATCH, oss.str());
++    }
++    return CompareTwoTensors(outvalue, expected_tensor, per_sample_tolerance, relative_per_sample_tolerance,
++                             post_processing, out_idx);
+   } else if (o.IsSparseTensor()) {
+ #if !defined(DISABLE_SPARSE_TENSORS)
+     TEST_RETURN_IF_NOT(expected_mlvalue.IsSparseTensor(), COMPARE_RESULT::TYPE_MISMATCH,
+@@ -419,7 +559,7 @@ std::pair<COMPARE_RESULT, std::string> CompareOrtValue(const OrtValue& o, const
+ 
+     for (size_t i = 0; i < expected_tensor_count; ++i) {
+       auto res = CompareTwoTensors(actual_tensor_seq.Get(i), expected_tensor_seq.Get(i), per_sample_tolerance, relative_per_sample_tolerance,
+-                                   post_processing);
++                                   post_processing, out_idx);
+       if (res.first != COMPARE_RESULT::SUCCESS) {
+         return res;
+       }
+diff --git a/onnxruntime/test/util/include/compare_ortvalue.h b/onnxruntime/test/util/include/compare_ortvalue.h
+index 24b74b9002..8269346528 100644
+--- a/onnxruntime/test/util/include/compare_ortvalue.h
++++ b/onnxruntime/test/util/include/compare_ortvalue.h
+@@ -24,7 +24,9 @@ enum class COMPARE_RESULT { SUCCESS,
+ std::pair<COMPARE_RESULT, std::string> CompareOrtValue(const OrtValue& real, const OrtValue& expected,
+                                                        double per_sample_tolerance,
+                                                        double relative_per_sample_tolerance, bool post_processing);
+-
++std::pair<COMPARE_RESULT, std::string> CompareOrtValue(const OrtValue& real, const OrtValue& expected,
++                                                       double per_sample_tolerance,
++                                                       double relative_per_sample_tolerance, bool post_processing, int32_t out_idx);
+ // verify if the 'value' matches the 'expected' ValueInfoProto. 'value' is a model output
+ std::pair<COMPARE_RESULT, std::string> VerifyValueInfo(const ONNX_NAMESPACE::ValueInfoProto& expected,
+                                                        const OrtValue* value);
+diff --git a/onnxruntime/test/util/include/test/compare_ortvalue.h b/onnxruntime/test/util/include/test/compare_ortvalue.h
+index 545df706c9..170eb9dc4c 100644
+--- a/onnxruntime/test/util/include/test/compare_ortvalue.h
++++ b/onnxruntime/test/util/include/test/compare_ortvalue.h
+@@ -28,7 +28,9 @@ enum class COMPARE_RESULT {
+ std::pair<COMPARE_RESULT, std::string> CompareOrtValue(const OrtValue& real, const OrtValue& expected,
+                                                        double per_sample_tolerance,
+                                                        double relative_per_sample_tolerance, bool post_processing);
+-
++std::pair<COMPARE_RESULT, std::string> CompareOrtValue(const OrtValue& real, const OrtValue& expected,
++                                                       double per_sample_tolerance,
++                                                       double relative_per_sample_tolerance, bool post_processing, int32_t out_idx);
+ // Compare two OrtValue numerically equal or not. The difference with CompareOrtValue is that this function
+ // will only check the numerical values of the OrtValue, and ignore the type, shape, etc.
+ //

--- a/onnxruntime/core/providers/vsinpu/builders/impl/clip_op_builder.h
+++ b/onnxruntime/core/providers/vsinpu/builders/impl/clip_op_builder.h
@@ -36,7 +36,7 @@ class ClipOpBuilder final : public BaseOpBuilder {
       return false;
     }
     if (node->SinceVersion() > 6) {
-      if (node->InputDefs().size() > 1 && !graph_viewer.IsInitializedTensor(node->InputDefs()[1]->Name())) {
+      if (node->InputDefs().size() > 1 && !graph_viewer.IsConstantInitializer(node->InputDefs()[1]->Name(),true)) {
         LOGS_DEFAULT(ERROR) << "Min/Max value must be const input or attribute.";
         return false;
       }

--- a/onnxruntime/core/providers/vsinpu/builders/impl/dequantize_op_builder.cc
+++ b/onnxruntime/core/providers/vsinpu/builders/impl/dequantize_op_builder.cc
@@ -42,7 +42,7 @@ bool DequantizeLinearOpBuilder::IsOpSupported(const onnxruntime::GraphViewer& gr
     LOGS_DEFAULT(WARNING) << "Not support block quantization.";
     return false;
   }
-  if (!graph_viewer.IsInitializedTensor(input_defs[scale_tensor]->Name()) || (input_defs.size() == 3 && !graph_viewer.IsInitializedTensor(input_defs[zero_point_tensor]->Name()))) {
+  if (!graph_viewer.IsConstantInitializer(input_defs[scale_tensor]->Name(), true) || (input_defs.size() == 3 && !graph_viewer.IsConstantInitializer(input_defs[zero_point_tensor]->Name(), true))) {
     LOGS_DEFAULT(WARNING) << "Only support const scale / zero pint input.";
     return false;
   }

--- a/onnxruntime/core/providers/vsinpu/builders/impl/norm_op_builder.h
+++ b/onnxruntime/core/providers/vsinpu/builders/impl/norm_op_builder.h
@@ -48,7 +48,7 @@ class BatchNormOpBuilder : public BaseOpBuilder {
       LOGS_DEFAULT(ERROR) << "VSINPU does not support 'spatial' parameter.";
       return false;
     }
-    if (!graph_viewer.IsInitializedTensor(input_defs[scale_tensor]->Name())) {
+    if (!graph_viewer.IsConstantInitializer(input_defs[scale_tensor]->Name(), true)) {
       LOGS_DEFAULT(ERROR) << "Not support mean/var/gamma/beta set as dynamic input yet.";
       return false;
     }

--- a/onnxruntime/core/providers/vsinpu/builders/impl/qlinearconv_op_builder.h
+++ b/onnxruntime/core/providers/vsinpu/builders/impl/qlinearconv_op_builder.h
@@ -65,7 +65,7 @@ class QLinearConvOpBuilder : public BaseOpBuilder {
       return false;
     }
 
-    if (!graph_viewer.IsInitializedTensor(input_defs[INPUT_TENSOR_SCALE]->Name()) || !graph_viewer.IsInitializedTensor(input_defs[WEIGHT_TENSOR]->Name())) {
+    if (!graph_viewer.IsConstantInitializer(input_defs[INPUT_TENSOR_SCALE]->Name(), true) || !graph_viewer.IsConstantInitializer(input_defs[WEIGHT_TENSOR]->Name(), true)) {
       LOGS_DEFAULT(ERROR) << "Not support quantization definitions or weights that are not constant yet.";
       return false;
     }
@@ -122,7 +122,8 @@ class QLinearConvOpBuilder : public BaseOpBuilder {
         w_zp = getParamAsVector<uint8_t>(inputs[WEIGHT_TENSOR_ZP]);
       int32_t value = std::visit([](auto& vec) {
         return static_cast<int32_t>(vec[0]);
-      }, w_zp);
+      },
+                                 w_zp);
       std::vector<int32_t> timvx_w_zp(w_scale.size(), value);
       if (timvx_w_zp[0] != 0) {
         WeightQuant.SetType(tim::vx::QuantType::ASYMMETRIC_PER_CHANNEL);

--- a/onnxruntime/core/providers/vsinpu/builders/impl/qlinearmatmul_op_builder.h
+++ b/onnxruntime/core/providers/vsinpu/builders/impl/qlinearmatmul_op_builder.h
@@ -47,7 +47,7 @@ class QLinearMatMulOpBuilder : public BaseOpBuilder {
       if (def->Name() == A_def->Name() || def->Name() == B_def->Name())
         continue;
       else {
-        if (!graph_viewer.IsInitializedTensor(def->Name())) {
+        if (!graph_viewer.IsConstantInitializer(def->Name(), true)) {
           LOGS_DEFAULT(WARNING) << "Scale and zero point must be known before setting graph.";
           return false;
         }

--- a/onnxruntime/core/providers/vsinpu/builders/impl/quantize_op_builder.cc
+++ b/onnxruntime/core/providers/vsinpu/builders/impl/quantize_op_builder.cc
@@ -42,7 +42,7 @@ bool QuantizeLinearOpBuilder::IsOpSupported(const onnxruntime::GraphViewer& grap
     LOGS_DEFAULT(WARNING) << "Not support block quantization.";
     return false;
   }
-  if (!graph_viewer.IsInitializedTensor(input_defs[scale_tensor]->Name()) || (input_defs.size() == 3 && !graph_viewer.IsInitializedTensor(input_defs[zero_point_tensor]->Name()))) {
+  if (!graph_viewer.IsConstantInitializer(input_defs[scale_tensor]->Name(), true) || (input_defs.size() == 3 && !graph_viewer.IsConstantInitializer(input_defs[zero_point_tensor]->Name(), true))) {
     LOGS_DEFAULT(WARNING) << "Only support const scale / zero point.";
     return false;
   }

--- a/onnxruntime/core/providers/vsinpu/builders/impl/tensor_op_builder.h
+++ b/onnxruntime/core/providers/vsinpu/builders/impl/tensor_op_builder.h
@@ -31,7 +31,7 @@ class ReshapeOpBuilder : public BaseOpBuilder {
   bool IsOpSupported(const onnxruntime::GraphViewer& graph_viewer,
                      const Node* node) const override {
     auto input_defs = node->InputDefs();
-    if (!graph_viewer.IsInitializedTensor(input_defs[1]->Name())) {
+    if (!graph_viewer.IsConstantInitializer(input_defs[1]->Name(), true)) {
       LOGS_DEFAULT(VERBOSE) << "New shape of reshape must be known";
       return false;
     }

--- a/onnxruntime/core/providers/vsinpu/patches/test_scripts/compare_cosine_sim.py
+++ b/onnxruntime/core/providers/vsinpu/patches/test_scripts/compare_cosine_sim.py
@@ -1,0 +1,25 @@
+import sys
+import numpy as np
+from numpy.linalg import norm
+
+def read_values(filename):
+    with open(filename, 'r') as file:
+        values = np.array([float(line.strip()) for line in file])
+    return values
+
+def cosine_similarity(vec1, vec2):
+    return np.dot(vec1, vec2) / (norm(vec1) * norm(vec2))
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: python cosine_similarity.py <file1> <file2>")
+        sys.exit(1)
+
+    file1 = sys.argv[1]
+    file2 = sys.argv[2]
+
+    vec1 = read_values(file1)
+    vec2 = read_values(file2)
+
+    similarity = cosine_similarity(vec1, vec2)
+    print(f"Cosine Similarity: {similarity}")

--- a/onnxruntime/core/providers/vsinpu/patches/test_scripts/compare_topn.py
+++ b/onnxruntime/core/providers/vsinpu/patches/test_scripts/compare_topn.py
@@ -1,0 +1,30 @@
+import sys
+
+def read_values(filename):
+    with open(filename, 'r') as file:
+        values = [float(line.strip()) for line in file]
+    return values
+
+def top_n(values, N):
+    return sorted(values, reverse=True)[:N]
+
+def compare_files(cpu_file, npu_file, N):
+    cpu_values = read_values(cpu_file)
+    npu_values = read_values(npu_file)
+
+    cpu_topn = top_n(cpu_values, N)
+    npu_topn = top_n(npu_values, N)
+
+    print(f"Top-{N} values in {cpu_file}: {cpu_topn}")
+    print(f"Top-{N} values in {npu_file}: {npu_topn}")
+
+if __name__ == "__main__":
+    if len(sys.argv) != 4:
+        print("Usage: python compare_topn.py <N> <cpu_file> <npu_file>")
+        sys.exit(1)
+
+    N = int(sys.argv[1])
+    cpu_file = sys.argv[2]
+    npu_file = sys.argv[3]
+
+    compare_files(cpu_file, npu_file, N)

--- a/onnxruntime/core/providers/vsinpu/patches/test_scripts/result_compare.sh
+++ b/onnxruntime/core/providers/vsinpu/patches/test_scripts/result_compare.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+res_file_dir=$1
+output_num=$2
+
+# specifying N value
+N=5
+
+for i in $(seq 0 $((output_num-1)));
+do
+  # 构建文件名
+  golden_file="${res_file_dir}/expected_res${i}.txt"
+  npu_file="${res_file_dir}/npu_res${i}.txt"
+
+  echo "Comparing Top-${N} for the output_${i}"
+  python3 compare_topn.py $N $golden_file $npu_file
+
+  echo "--------------------------------"
+
+  echo "Comparing Cosine Similarity for output_${i}:"
+  python3 compare_cosine_sim.py $golden_file $npu_file
+
+  echo ""
+done

--- a/onnxruntime/core/providers/vsinpu/vsinpu_execution_provider.cc
+++ b/onnxruntime/core/providers/vsinpu/vsinpu_execution_provider.cc
@@ -350,7 +350,7 @@ Status VSINPUExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& fu
                             << graph_viewer.IsInitializedTensor(tensor->Name());
       auto input = std::make_shared<vsi::npu::GraphIOInfo>();
       input->name = tensor->Name();
-      if (graph_viewer.IsInitializedTensor(tensor->Name())) {
+      if (graph_viewer.IsConstantInitializer(tensor->Name(),true)) {
         input->is_initializer = true;
       } else {
         input->is_initializer = false;


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- Replace some api 
- Refine convopbuilder by adding depthwise conv branch
- Added test_scripts directory


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- An initialized tensor is not always const tensor, because onnxruntime optimizer may change it into input attribute
- To verify the correctness of the results, we need to record the output of the NPU runs and perform the appropriate mathematical comparison with the golden results.


